### PR TITLE
kas: replace refspec by branch

### DIFF
--- a/.config.yaml
+++ b/.config.yaml
@@ -9,19 +9,19 @@ target:
 repos:
   bitbake:
     url: "https://git.openembedded.org/bitbake"
-    refspec: "2.0"
+    branch: "2.0"
     layers:
       .: excluded
 
   openembedded-core:
     url: "https://git.openembedded.org/openembedded-core"
-    refspec: kirkstone
+    branch: kirkstone
     layers:
       meta:
 
   meta-arm:
     url: "git://git.yoctoproject.org/meta-arm"
-    refspec: kirkstone
+    branch: kirkstone
     layers:
       meta-arm-toolchain:
       meta-arm:


### PR DESCRIPTION
The current kas configuration uses the deprecated "refspec" kirkstone to sync the layers. This creates one warning per layer during kas initialization.

This PR removes the deprecated refspec to use the branch to sync the layers, to remove the warnings while still fetching the latest kirkstone revision.