### PR TITLE
conf/layer.conf: Add meta-arm layer dependency

### DIFF
--- a/meta-kiss/conf/layer.conf
+++ b/meta-kiss/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "meta-kiss"
 BBFILE_PATTERN_meta-kiss = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-kiss = "9"
 
-LAYERDEPENDS_meta-kiss = "core"
+LAYERDEPENDS_meta-kiss = "core meta-arm"
 LAYERSERIES_COMPAT_meta-kiss = "kirkstone"


### PR DESCRIPTION
Add meta-arm as a required layer dependency to ensure proper error reporting when the layer is missing from the build configuration.