### PR TITLE
README: Fix references to Yocto Kirkstone

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ modify a kernel defconfig.
 
 In the end we hope you like the advantages of this clean setup:
 
- * uses Yocto kirkstone and builds on modern distros without the need of a
+ * uses Yocto scarthgap and builds on modern distros without the need of a
    container -- which you can of course use when it makes sense to
  * no manual cloning of layers: kas does it all for you
  * no manual configuration, except of course for selecting a machine

--- a/meta-kiss/README
+++ b/meta-kiss/README
@@ -6,10 +6,10 @@ Dependencies
 ============
 
   URI: https://git.openembedded.org/openembedded-core
-  branch: kirkstone
+  branch: scarthgap
 
   URI: git://git.yoctoproject.org/meta-arm
-  branch: kirkstone
+  branch: scarthgap
 
 Patches
 =======


### PR DESCRIPTION
We have stitched to Scarthgap, so remove any reference to Kirkstone.