### PR TITLE
README.md: suggesting editing site.conf, not local.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ kas checkout
 
 # For i.MX93, you will have to accept the NXP EULA, after reading
 # meta-kiss/recipes-bsp/firmware-imx/files/EULA:
-echo 'LICENSE_FLAGS_ACCEPTED += "NXP_EULA_v58"' >> conf/local.conf
+echo 'LICENSE_FLAGS_ACCEPTED += "NXP_EULA_v58"' >> conf/site.conf
 
 # Run your first build
 bitbake kiss-image


### PR DESCRIPTION
kas overwrites local.conf every time it runs, thus writing valuble info in that file is not a good idea when using kas. Fix by suggesting to use site.conf instead.