### PR TITLE
README.md: correct kiss-image-dogbonedark.rootfs.wic filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ ls -l tmp-glibc/deploy/images/dogbonedark/
 
 # Flash the image (replace machine name, and use your uSD card device
 # instead of XYZ!):
-sudo bmaptool copy tmp-glibc/deploy/images/dogbonedark/kiss-image-dogbonedark.wic /dev/XYZ
+sudo bmaptool copy tmp-glibc/deploy/images/dogbonedark/kiss-image-dogbonedark.rootfs.wic /dev/XYZ
 ```
 
 # That's all!


### PR DESCRIPTION
The wic images have the filename *.rootfs.wic, so correct the README.md documentation to reflect the correct filename.