### PR TITLE
kas: switch meta-arm fetch URL to HTTPS

### DIFF
--- a/.config.yaml
+++ b/.config.yaml
@@ -20,7 +20,7 @@ repos:
       meta:
 
   meta-arm:
-    url: "git://git.yoctoproject.org/meta-arm"
+    url: "https://git.yoctoproject.org/meta-arm"
     branch: scarthgap
     layers:
       meta-arm-toolchain:


### PR DESCRIPTION
Fetching via git:// hangs.
The git:// URL is no longer listed on the upstream website [1]. Use the HTTPS endpoint instead.

[1] https://git.yoctoproject.org/meta-arm